### PR TITLE
Misc updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,3 +7,10 @@ install:
   - git submodule update --init --recursive
 build:
   project: OP2Script.sln
+after_build:
+  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-Build%APPVEYOR_BUILD_VERSION%-%CONFIGURATION%"
+  - 7z a "%PackageBaseName%.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.dll"
+  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.pdb"
+artifacts:
+  - path: "*.zip"
+    name: BuildArtifacts

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -8,7 +8,6 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 	{
 		DisableThreadLibraryCalls(hinstDLL);
 		HFLInit();
-		DisableThreadLibraryCalls(hinstDLL);
 	}
 	else if (fdwReason == DLL_PROCESS_DETACH)
 	{

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -1,17 +1,15 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <HFL/Source/HFL.h>
+
 
 BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
 	if (fdwReason == DLL_PROCESS_ATTACH)
 	{
 		DisableThreadLibraryCalls(hinstDLL);
-		HFLInit();
 	}
 	else if (fdwReason == DLL_PROCESS_DETACH)
 	{
-		HFLCleanup();
 	}
 
 	return true;

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -6,8 +6,8 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
 	if (fdwReason == DLL_PROCESS_ATTACH)
 	{
-		HFLInit();
 		DisableThreadLibraryCalls(hinstDLL);
+		HFLInit();
 	}
 	else if (fdwReason == DLL_PROCESS_DETACH)
 	{

--- a/LevelMain.cpp
+++ b/LevelMain.cpp
@@ -37,7 +37,7 @@ Export int InitProc()
 	TethysGame::CreateUnit(truck, map_id::mapCargoTruck, garage.Location(), Player0, mapNone, 0);
 
 	truck.PutInGarage(0, garage.Location().x, garage.Location().y);
-	
+
 	return true;
 }
 


### PR DESCRIPTION
This fixes a few things included in PR #1, which isn't quite ready yet to merge. This also brings in a few upstream changes from the LevelTemplate project. There is a bit of overlap in changes from the two sources.

For reference, the upstream reference was added (locally) with:
```
git remote add upstream https://github.com/OutpostUniverse/LevelTemplate.git
```

----

I removed the `HFLInit()` and `HFLCleanup()` calls, along with the HFL header include. The project doesn't use HFL, and won't need to. Removing uses of HFL makes the project easier to compile, particularly since HFL has no Linux makefile, and so doesn't produce a library needed for the link step to satisfy function references.

Edit: For reference, this mostly compiles (but fails to link) with:
```
mingw -shared -I OP2MissionSDK/ *.cpp -L OP2MissionSDK/Outpost2DLL/Lib/ -lOutpost2DLL
```
